### PR TITLE
Add ExtFont.get(Narrow|Wide)Font(BMP|PNG) methods

### DIFF
--- a/src/main/java/io/github/eb4j/EBException.java
+++ b/src/main/java/io/github/eb4j/EBException.java
@@ -30,6 +30,8 @@ public class EBException extends Exception {
     public static final int FAILED_SEEK_FILE = 6;
     /** Error code: cannot find unicode map. */
     public static final int CANT_FIND_UNICODEMAP = 7;
+    /** Error code: failed to convert gaiji image. */
+    public static final int FAILED_CONVERT_GAIJI = 8;
 
     /** Error messages */
     private static final String[] ERR_MSG = {

--- a/src/main/java/io/github/eb4j/ExtFont.java
+++ b/src/main/java/io/github/eb4j/ExtFont.java
@@ -3,12 +3,7 @@ package io.github.eb4j;
 import io.github.eb4j.io.EBFile;
 import io.github.eb4j.io.BookInputStream;
 import io.github.eb4j.util.ByteUtil;
-
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
+import io.github.eb4j.util.ImageUtil;
 
 /**
  * ifeval::["{lang}" == "en"]
@@ -83,104 +78,6 @@ public class ExtFont {
                                                + type);
         }
         _fontType = type;
-    }
-
-    /**
-     * Convert EB gaiji bitmap to BMP image format.
-     * @param data EB gaiji byte array.
-     * @param width width in pixel of gaiji
-     * @param height height in pixel of gaiji
-     * @return BMP format gaiji image.
-     */
-    protected byte[] bitmap2BMP(final byte[] data, final int width, final int height) {
-        final int BMP_PREAMBLE_LENGTH = 62;
-        final byte[] bmpPreamble = new byte[] {
-                // Type
-                'B', 'M',
-                // File size (set at run time)
-                0x00, 0x00, 0x00, 0x00,
-                // Reserved
-                0x00, 0x00, 0x00, 0x00,
-                // offset of bitmap bits part
-                0x3e, 0x00, 0x00, 0x00,
-                // size of bitmap info part
-                0x28, 0x00, 0x00, 0x00,
-                // width (set at run time)
-                0x00, 0x00, 0x00, 0x00,
-                // height (set at run time)
-                0x00, 0x00, 0x00, 0x00,
-                // planes
-                0x01, 0x00,
-                // bits per pixsels
-                0x01, 0x00,
-                // compression mode
-                0x00, 0x00, 0x00, 0x00,
-                // size of bitmap bits part (set at run time)
-                0x00, 0x00, 0x00, 0x00,
-                // X pixels per meter
-                0x6d, 0x0b, 0x00, 0x00,
-                // Y pixels per meter
-                0x6d, 0x0b, 0x00, 0x00,
-                // Colors
-                0x02, 0x00, 0x00, 0x00,
-                // Important colors
-                0x02, 0x00, 0x00, 0x00,
-                // RGB quad of color 0   RGB quad of color 1
-                (byte)0xff, (byte)0xff, (byte)0xff, 0x00, 0x00, 0x00, 0x00, 0x00
-        };
-
-        int linePad;
-        if (width % 32 == 0) {
-            linePad = 0;
-        } else if (width % 32 <= 8) {
-            linePad = 3;
-        } else if (width % 32 <= 16) {
-            linePad = 2;
-        } else if (width % 32 <= 24) {
-            linePad = 1;
-        } else {
-            linePad = 0;
-        }
-
-        int dataSize = height * (width / 2 + linePad);
-        int fileSize = dataSize + BMP_PREAMBLE_LENGTH;
-
-        byte[] bmp = new byte[fileSize];
-        System.arraycopy(bmpPreamble, 0, bmp, 0, BMP_PREAMBLE_LENGTH);
-        //
-        bmp[2] = (byte) (fileSize & 0xff);
-        bmp[3] = (byte) ((byte) (fileSize >> 8) & 0xff);
-        bmp[4] = (byte) ((byte) (fileSize >> 16) & 0xff);
-        bmp[5] = (byte) ((byte) (fileSize >> 24) & 0xff);
-
-        bmp[18] = (byte) (width & 0xff);
-        bmp[19] = (byte) ((byte) (width >> 8) & 0xff);
-        bmp[20] = (byte) ((byte) (width >> 16) & 0xff);
-        bmp[21] = (byte) ((byte) (width >> 24) & 0xff);
-
-        bmp[22] = (byte) (height & 0xff);
-        bmp[23] = (byte) ((height >> 8) & 0xff);
-        bmp[24] = (byte) ((height >> 16) & 0xff);
-        bmp[25] = (byte) ((height >> 24) & 0xff);
-
-        bmp[34] = (byte)(dataSize & 0xff);
-        bmp[35] = (byte)((dataSize >> 8) & 0xff);
-        bmp[36] = (byte)((dataSize >> 16) & 0xff);
-        bmp[37] = (byte)((dataSize >> 24) & 0xff);
-
-        int bitmapLineLength = (width + 7) / 8;
-
-        int i = height -1;
-        int k = BMP_PREAMBLE_LENGTH;
-        while (i >= 0) {
-            System.arraycopy(data, bitmapLineLength * i, bmp, k, bitmapLineLength);
-            i--;
-            k += bitmapLineLength;
-            for (int j = 0; j < linePad; j++, k++) {
-                bmp[k]  = 0x00;
-            }
-        }
-        return bmp;
     }
 
     /**
@@ -421,7 +318,7 @@ public class ExtFont {
      * @throws EBException if file read error is happened.
      */
     public byte[] getNarrowFontBMP(final int code) throws EBException {
-        return bitmap2BMP(_getFont(NARROW, code), getNarrowFontWidth(), getFontHeight());
+        return ImageUtil.bitmapToBMP(_getFont(NARROW, code), getNarrowFontWidth(), getFontHeight());
     }
 
     /**
@@ -431,7 +328,7 @@ public class ExtFont {
      * @throws EBException if file read error is happened.
      */
     public byte[] getWideFontBMP(final int code) throws EBException {
-        return bitmap2BMP(_getFont(WIDE, code), getWideFontWidth(), getFontHeight());
+        return ImageUtil.bitmapToBMP(_getFont(WIDE, code), getWideFontWidth(), getFontHeight());
     }
 
     /**
@@ -441,15 +338,7 @@ public class ExtFont {
      * @throws EBException if file read error is happened.
      */
     public byte[] getNarrowFontPNG(final int code) throws EBException {
-        byte[] bmp = bitmap2BMP(_getFont(NARROW, code), getNarrowFontWidth(), getFontHeight());
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            final BufferedImage res = ImageIO.read(new ByteArrayInputStream(bmp));
-            ImageIO.write(res, "png", baos);
-            baos.flush();
-            return baos.toByteArray();
-        } catch (IOException e) {
-            throw new EBException(EBException.FAILED_CONVERT_GAIJI);
-        }
+        return ImageUtil.bitmapToPNG(_getFont(NARROW, code), getNarrowFontWidth(), getFontHeight());
     }
 
     /**
@@ -459,15 +348,7 @@ public class ExtFont {
      * @throws EBException if file read error is happened.
      */
     public byte[] getWideFontPNG(final int code) throws EBException {
-        byte[] bmp = bitmap2BMP(_getFont(WIDE, code), getWideFontWidth(), getFontHeight());
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            final BufferedImage res = ImageIO.read(new ByteArrayInputStream(bmp));
-            ImageIO.write(res, "png", baos);
-            baos.flush();
-            return baos.toByteArray();
-        } catch (IOException e) {
-            throw new EBException(EBException.FAILED_CONVERT_GAIJI);
-        }
+        return ImageUtil.bitmapToPNG(_getFont(WIDE, code), getWideFontWidth(), getFontHeight());
     }
 
     /**

--- a/src/main/java/io/github/eb4j/ExtFont.java
+++ b/src/main/java/io/github/eb4j/ExtFont.java
@@ -4,6 +4,12 @@ import io.github.eb4j.io.EBFile;
 import io.github.eb4j.io.BookInputStream;
 import io.github.eb4j.util.ByteUtil;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
 /**
  * ifeval::["{lang}" == "en"]
  * = GAIJI font class.
@@ -79,6 +85,103 @@ public class ExtFont {
         _fontType = type;
     }
 
+    /**
+     * Convert EB gaiji bitmap to BMP image format.
+     * @param data EB gaiji byte array.
+     * @param width width in pixel of gaiji
+     * @param height height in pixel of gaiji
+     * @return BMP format gaiji image.
+     */
+    protected byte[] bitmap2BMP(final byte[] data, final int width, final int height) {
+        final int BMP_PREAMBLE_LENGTH = 62;
+        final byte[] bmpPreamble = new byte[] {
+                // Type
+                'B', 'M',
+                // File size (set at run time)
+                0x00, 0x00, 0x00, 0x00,
+                // Reserved
+                0x00, 0x00, 0x00, 0x00,
+                // offset of bitmap bits part
+                0x3e, 0x00, 0x00, 0x00,
+                // size of bitmap info part
+                0x28, 0x00, 0x00, 0x00,
+                // width (set at run time)
+                0x00, 0x00, 0x00, 0x00,
+                // height (set at run time)
+                0x00, 0x00, 0x00, 0x00,
+                // planes
+                0x01, 0x00,
+                // bits per pixsels
+                0x01, 0x00,
+                // compression mode
+                0x00, 0x00, 0x00, 0x00,
+                // size of bitmap bits part (set at run time)
+                0x00, 0x00, 0x00, 0x00,
+                // X pixels per meter
+                0x6d, 0x0b, 0x00, 0x00,
+                // Y pixels per meter
+                0x6d, 0x0b, 0x00, 0x00,
+                // Colors
+                0x02, 0x00, 0x00, 0x00,
+                // Important colors
+                0x02, 0x00, 0x00, 0x00,
+                // RGB quad of color 0   RGB quad of color 1
+                (byte)0xff, (byte)0xff, (byte)0xff, 0x00, 0x00, 0x00, 0x00, 0x00
+        };
+
+        int linePad;
+        if (width % 32 == 0) {
+            linePad = 0;
+        } else if (width % 32 <= 8) {
+            linePad = 3;
+        } else if (width % 32 <= 16) {
+            linePad = 2;
+        } else if (width % 32 <= 24) {
+            linePad = 1;
+        } else {
+            linePad = 0;
+        }
+
+        int dataSize = height * (width / 2 + linePad);
+        int fileSize = dataSize + BMP_PREAMBLE_LENGTH;
+
+        byte[] bmp = new byte[fileSize];
+        System.arraycopy(bmpPreamble, 0, bmp, 0, BMP_PREAMBLE_LENGTH);
+        //
+        bmp[2] = (byte) (fileSize & 0xff);
+        bmp[3] = (byte) ((byte) (fileSize >> 8) & 0xff);
+        bmp[4] = (byte) ((byte) (fileSize >> 16) & 0xff);
+        bmp[5] = (byte) ((byte) (fileSize >> 24) & 0xff);
+
+        bmp[18] = (byte) (width & 0xff);
+        bmp[19] = (byte) ((byte) (width >> 8) & 0xff);
+        bmp[20] = (byte) ((byte) (width >> 16) & 0xff);
+        bmp[21] = (byte) ((byte) (width >> 24) & 0xff);
+
+        bmp[22] = (byte) (height & 0xff);
+        bmp[23] = (byte) ((height >> 8) & 0xff);
+        bmp[24] = (byte) ((height >> 16) & 0xff);
+        bmp[25] = (byte) ((height >> 24) & 0xff);
+
+        bmp[34] = (byte)(dataSize & 0xff);
+        bmp[35] = (byte)((dataSize >> 8) & 0xff);
+        bmp[36] = (byte)((dataSize >> 16) & 0xff);
+        bmp[37] = (byte)((dataSize >> 24) & 0xff);
+
+        int bitmapLineLength = (width + 7) / 8;
+
+        int i = height -1;
+        int k = BMP_PREAMBLE_LENGTH;
+        while (i >= 0) {
+            System.arraycopy(data, bitmapLineLength * i, bmp, k, bitmapLineLength);
+            i--;
+            k += bitmapLineLength;
+            for (int j = 0; j < linePad; j++, k++) {
+                bmp[k]  = 0x00;
+            }
+        }
+        return bmp;
+    }
 
     /**
      * Reading a gaiji properties.
@@ -309,6 +412,62 @@ public class ExtFont {
      */
     public int getWideFontSize() {
         return FONT_SIZE[WIDE][_fontType];
+    }
+
+    /**
+     * Returns a BMP image data of half-width Gaiji.
+     * @param code gaiji code.
+     * @return BMP data of half-width Gaiji.
+     * @throws EBException if file read error is happened.
+     */
+    public byte[] getNarrowFontBMP(final int code) throws EBException {
+        return bitmap2BMP(_getFont(NARROW, code), getNarrowFontWidth(), getFontHeight());
+    }
+
+    /**
+     * Returns a BMP image data of full-width Gaiji.
+     * @param code gaiji code.
+     * @return BMP data of full-width Gaiji.
+     * @throws EBException if file read error is happened.
+     */
+    public byte[] getWideFontBMP(final int code) throws EBException {
+        return bitmap2BMP(_getFont(WIDE, code), getWideFontWidth(), getFontHeight());
+    }
+
+    /**
+     * Returns a PNG image data of half-width Gaiji.
+     * @param code gaiji code.
+     * @return PNG data of half-width Gaiji.
+     * @throws EBException if file read error is happened.
+     */
+    public byte[] getNarrowFontPNG(final int code) throws EBException {
+        byte[] bmp = bitmap2BMP(_getFont(NARROW, code), getNarrowFontWidth(), getFontHeight());
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            final BufferedImage res = ImageIO.read(new ByteArrayInputStream(bmp));
+            ImageIO.write(res, "png", baos);
+            baos.flush();
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new EBException(EBException.FAILED_CONVERT_GAIJI);
+        }
+    }
+
+    /**
+     * Returns a PNG image data of full-width Gaiji.
+     * @param code gaiji code.
+     * @return PNG data of full-width Gaiji.
+     * @throws EBException if file read error is happened.
+     */
+    public byte[] getWideFontPNG(final int code) throws EBException {
+        byte[] bmp = bitmap2BMP(_getFont(WIDE, code), getWideFontWidth(), getFontHeight());
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            final BufferedImage res = ImageIO.read(new ByteArrayInputStream(bmp));
+            ImageIO.write(res, "png", baos);
+            baos.flush();
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new EBException(EBException.FAILED_CONVERT_GAIJI);
+        }
     }
 
     /**

--- a/src/main/java/io/github/eb4j/util/ImageUtil.java
+++ b/src/main/java/io/github/eb4j/util/ImageUtil.java
@@ -62,6 +62,104 @@ public final class ImageUtil {
 
 
     /**
+     * Convert EB gaiji bitmap to BMP image format.
+     * @param data EB gaiji byte array.
+     * @param width width in pixel of gaiji
+     * @param height height in pixel of gaiji
+     * @return BMP format gaiji image.
+     */
+    public static byte[] bitmapToBMP(final byte[] data, final int width, final int height) {
+        final int BMP_PREAMBLE_LENGTH = 62;
+        final byte[] bmpPreamble = new byte[] {
+                // Type
+                'B', 'M',
+                // File size (set at run time)
+                0x00, 0x00, 0x00, 0x00,
+                // Reserved
+                0x00, 0x00, 0x00, 0x00,
+                // offset of bitmap bits part
+                0x3e, 0x00, 0x00, 0x00,
+                // size of bitmap info part
+                0x28, 0x00, 0x00, 0x00,
+                // width (set at run time)
+                0x00, 0x00, 0x00, 0x00,
+                // height (set at run time)
+                0x00, 0x00, 0x00, 0x00,
+                // planes
+                0x01, 0x00,
+                // bits per pixsels
+                0x01, 0x00,
+                // compression mode
+                0x00, 0x00, 0x00, 0x00,
+                // size of bitmap bits part (set at run time)
+                0x00, 0x00, 0x00, 0x00,
+                // X pixels per meter
+                0x6d, 0x0b, 0x00, 0x00,
+                // Y pixels per meter
+                0x6d, 0x0b, 0x00, 0x00,
+                // Colors
+                0x02, 0x00, 0x00, 0x00,
+                // Important colors
+                0x02, 0x00, 0x00, 0x00,
+                // RGB quad of color 0   RGB quad of color 1
+                (byte)0xff, (byte)0xff, (byte)0xff, 0x00, 0x00, 0x00, 0x00, 0x00
+        };
+
+        int linePad;
+        if (width % 32 == 0) {
+            linePad = 0;
+        } else if (width % 32 <= 8) {
+            linePad = 3;
+        } else if (width % 32 <= 16) {
+            linePad = 2;
+        } else if (width % 32 <= 24) {
+            linePad = 1;
+        } else {
+            linePad = 0;
+        }
+
+        int dataSize = height * (width / 2 + linePad);
+        int fileSize = dataSize + BMP_PREAMBLE_LENGTH;
+
+        byte[] bmp = new byte[fileSize];
+        System.arraycopy(bmpPreamble, 0, bmp, 0, BMP_PREAMBLE_LENGTH);
+        //
+        bmp[2] = (byte) (fileSize & 0xff);
+        bmp[3] = (byte) ((byte) (fileSize >> 8) & 0xff);
+        bmp[4] = (byte) ((byte) (fileSize >> 16) & 0xff);
+        bmp[5] = (byte) ((byte) (fileSize >> 24) & 0xff);
+
+        bmp[18] = (byte) (width & 0xff);
+        bmp[19] = (byte) ((byte) (width >> 8) & 0xff);
+        bmp[20] = (byte) ((byte) (width >> 16) & 0xff);
+        bmp[21] = (byte) ((byte) (width >> 24) & 0xff);
+
+        bmp[22] = (byte) (height & 0xff);
+        bmp[23] = (byte) ((height >> 8) & 0xff);
+        bmp[24] = (byte) ((height >> 16) & 0xff);
+        bmp[25] = (byte) ((height >> 24) & 0xff);
+
+        bmp[34] = (byte)(dataSize & 0xff);
+        bmp[35] = (byte)((dataSize >> 8) & 0xff);
+        bmp[36] = (byte)((dataSize >> 16) & 0xff);
+        bmp[37] = (byte)((dataSize >> 24) & 0xff);
+
+        int bitmapLineLength = (width + 7) / 8;
+
+        int i = height -1;
+        int k = BMP_PREAMBLE_LENGTH;
+        while (i >= 0) {
+            System.arraycopy(data, bitmapLineLength * i, bmp, k, bitmapLineLength);
+            i--;
+            k += bitmapLineLength;
+            for (int j = 0; j < linePad; j++, k++) {
+                bmp[k]  = 0x00;
+            }
+        }
+        return bmp;
+    }
+
+    /**
      * デフォルトの圧縮レベル、前景色を黒、背景色を白、無透過で
      * ビットマップイメージをPNG (Portable Network Graphics) に変換します。
      *


### PR DESCRIPTION
Introduce new Gaiji methods

This add four public methods:
- Return PNG image of gaiji font for Narrow and Wide width
- Return BMP image of gaiji font for Narrow and Wide width

Signed-off-by: Hiroshi Miura <miurahr@linux.com>